### PR TITLE
Enrich Fields with Resolve, Description and Deprecations

### DIFF
--- a/src/spec/expectations.js
+++ b/src/spec/expectations.js
@@ -32,6 +32,22 @@ export const SingleInterface =
   }
 }`
 
+export const FieldResolver =
+`{
+  Hello: function () {
+    return new GraphQLObjectType({
+      name: "Hello",
+      fields: () => ({
+        world: {
+          type: GraphQLString,
+          resolve: () => {
+            return "foo";
+          } }
+      })
+    });
+  }
+}`
+
 export const StringType =
 `{
   Hello: function () {
@@ -195,7 +211,8 @@ export const StarWars =
           type: GraphQLString
         },
         friends: {
-          type: new GraphQLList(this.Character())
+          type: new GraphQLList(this.Character()),
+          resolve: droid => getFriends(droid)
         },
         appearsIn: {
           type: new GraphQLList(this.Episode())

--- a/src/spec/index-spec.js
+++ b/src/spec/index-spec.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as expectations from "./expectations";
 
-import { schema } from "./starWarsSchema";
+import { schema, fields } from "./starWarsSchema";
 
 const transform = (str) => {
   return require("babel-core").transform(str, {
@@ -12,7 +12,15 @@ const transform = (str) => {
 describe('Schema', () => {
   it('StarWars', () => {
     const code = schema;
-    expect(transform('graphql`${`' + code + '`}`')).to.equal(`${expectations.StarWars}`);
+    expect(transform('graphql`${`' + code + '`}${' + fields +'}`')).to.equal(`${expectations.StarWars}`);
+  });
+
+  describe('Resolvers', () => {
+    it('Field', () => {
+      const code = 'graphql`${ `type Hello { world: String }`}' +
+                           '${ { Hello: { world: { resolve: () => { return "foo"; } } } } }`'
+      expect(transform(code)).to.equal(`${expectations.FieldResolver}`);
+    });
   });
 
   describe('Directives', () => {

--- a/src/spec/starWarsSchema.js
+++ b/src/spec/starWarsSchema.js
@@ -24,3 +24,13 @@ type Droid implements Character {
   appearsIn: [Episode]
   primaryFunction: String
 }`
+
+export const fields = `
+{
+  Droid: {
+    friends: {
+      resolve: droid => getFriends(droid),
+    }
+  }
+}
+`;


### PR DESCRIPTION
Working spike to enrich fields with relevant `resolve`, `description` and `deprecations`.  Currently with this spike (can also see spec) you would write the following template string in your application.

Curret proposal for template string would be:

```
graphql`${schemaString} ${enrichObject}`:
```

e.g.

```
graphql`${`
  type Hello {
    world: String
  }
`}${
{
  Hello: { 
    world: { 
      resolve: () => { return "foo"; },
      description: "Gives you the whole world.",
      isDeprecated: true,
      deprecationReason: "The world was too big."
     }
   }
}}`
```

Code works but is very rough, whole thing needs a spring clean see #3.
